### PR TITLE
Markdown 3.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
 
 python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "nightly"
-  - "pypy"
+  - "pypy3"
 
 env:
   - WITH_PYGMENTS=0
@@ -16,8 +15,8 @@ env:
 
 matrix:
   exclude:
-    # pygment does not support Python 3.2
-    - python: "3.2"
+    # pygment does not support Python 3.4
+    - python: "3.4"
       env: WITH_PYGMENTS=1
   allow_failures:
     - python: "nightly"
@@ -28,8 +27,7 @@ install:
   - pip install .
 
 script:
-  # coverage >= 4 does not support Python 3.2
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then python test.py; else coverage run test.py; fi
+  - coverage run test.py
 
 after_success:
   - codecov

--- a/gfm/__init__.py
+++ b/gfm/__init__.py
@@ -27,3 +27,52 @@ TaskListExtension = tasklist.TaskListExtension
 __all__ = ['AutolinkExtension', 'AutomailExtension', 'HiddenHiliteExtension',
            'SemiSaneListExtension', 'SpacedLinkExtension',
            'StrikethroughExtension', 'TaskListExtension']
+
+from markdown.extensions.nl2br import Nl2BrExtension
+from mdx_partial_gfm import PartialGithubFlavoredMarkdownExtension
+
+
+def makeExtension(*args, **kwargs):
+    return GithubFlavoredMarkdownExtension(*args, **kwargs)
+
+
+class GithubFlavoredMarkdownExtension(PartialGithubFlavoredMarkdownExtension):
+    """
+    An extension that is as compatible as possible with GitHub-flavored
+    Markdown (GFM).
+
+    This extension aims to be compatible with the standard GFM that GitHub uses
+    for comments and issues. It has all the extensions described in the `GFM
+    documentation`_, except for intra-GitHub links to commits, repositories,
+    and issues.
+
+    Note that Markdown-formatted gists and files (including READMEs) on GitHub
+    use a slightly different variant of GFM. For that, use
+    :class:`mdx_partial_gfm.PartialGithubFlavoredMarkdownExtension`.
+
+    .. _GFM documentation: https://guides.github.com/features/mastering-markdown/
+    """
+    config = {
+        'linenums': [None,
+                     "Use lines numbers. True=yes, False=no, None=auto"],
+        'guess_lang': [True,
+                       "Automatic language detection - Default: True"],
+        'css_class': ["highlight",
+                      "Set class name for wrapper <div> - "
+                      "Default: codehilite"],
+        'pygments_style': ['default',
+                           'Pygments HTML Formatter Style '
+                           '(Colorscheme) - Default: default'],
+        'noclasses': [False,
+                      'Use inline styles instead of CSS classes - '
+                      'Default false'],
+        'use_pygments': [True,
+                         'Use Pygments to Highlight code blocks. '
+                         'Disable if using a JavaScript library. '
+                         'Default: True'],
+    }
+
+    def extendMarkdown(self, md, md_globals):
+        PartialGithubFlavoredMarkdownExtension.extendMarkdown(self, md,
+                                                              md_globals)
+        Nl2BrExtension().extendMarkdown(md)

--- a/gfm/hidden_hilite.py
+++ b/gfm/hidden_hilite.py
@@ -38,3 +38,6 @@ class HiddenHiliteExtension(CodeHiliteExtension):
 
     def extendMarkdown(self, md, md_globals):
         md.registerExtension(self)
+        for key in self.config:
+            if key in md_globals:
+                self.config[key][0] = md_globals[key][0]

--- a/gfm/spaced_link.py
+++ b/gfm/spaced_link.py
@@ -35,21 +35,40 @@ from __future__ import unicode_literals
 
 import markdown
 
-BRK = markdown.inlinepatterns.BRK
 NOIMG = markdown.inlinepatterns.NOIMG
 SPACE = r'(?:\s*(?:\r\n|\r|\n)?\s*)'
 
-SPACED_LINK_RE = markdown.inlinepatterns.LINK_RE.replace(
-    NOIMG + BRK, NOIMG + BRK + SPACE)
+SPACED_LINK_RE = r"\[.+\]\s+\(.+\)"
 
-SPACED_REFERENCE_RE = markdown.inlinepatterns.REFERENCE_RE.replace(
-    NOIMG + BRK, NOIMG + BRK + SPACE)
+SPACED_REFERENCE_RE = markdown.inlinepatterns.REFERENCE_RE
 
-SPACED_IMAGE_LINK_RE = markdown.inlinepatterns.IMAGE_LINK_RE.replace(
-    r'\!' + BRK, r'\!' + BRK + SPACE)
+SPACED_IMAGE_LINK_RE = markdown.inlinepatterns.IMAGE_LINK_RE
 
-SPACED_IMAGE_REFERENCE_RE = markdown.inlinepatterns.IMAGE_REFERENCE_RE.replace(
-    r'\!' + BRK, r'\!' + BRK + SPACE)
+SPACED_IMAGE_REFERENCE_RE = markdown.inlinepatterns.IMAGE_REFERENCE_RE
+
+import re
+from markdown.inlinepatterns import LinkInlineProcessor, ImageInlineProcessor, ReferenceInlineProcessor, ImageReferenceInlineProcessor, LINK_RE, IMAGE_LINK_RE
+
+
+class SpacedLinkInlineProcessor(LinkInlineProcessor):
+    """ Return a link element from the given match. """
+    RE_LINK = re.compile(
+        r'''\s+\(\s*(?:(<[^<>]*>)\s*(?:('[^']*'|"[^"]*")\s*)?\))?''', re.DOTALL | re.UNICODE)
+
+
+class SpacedImageInlineProcessor(ImageInlineProcessor):
+    """ Return a link element from the given match. """
+    RE_LINK = re.compile(
+        r'''\s+\(\s*(?:(<[^<>]*>)\s*(?:('[^']*'|"[^"]*")\s*)?\))?''', re.DOTALL | re.UNICODE)
+
+
+class SpacedReferenceInlineProcessor(ReferenceInlineProcessor):
+    """ Return a link element from the given match. """
+    RE_LINK = re.compile(r'\s+\[([^\]]*)\]', re.DOTALL | re.UNICODE)
+
+
+class SpacedImageReferenceInlineProcessor(ImageReferenceInlineProcessor):
+    RE_LINK = re.compile(r'\s+\[([^\]]*)\]', re.DOTALL | re.UNICODE)
 
 
 class SpacedLinkExtension(markdown.Extension):
@@ -58,12 +77,19 @@ class SpacedLinkExtension(markdown.Extension):
     """
 
     def extendMarkdown(self, md, md_globals):
-        md.inlinePatterns['link'] = \
-            markdown.inlinepatterns.LinkPattern(SPACED_LINK_RE, md)
-        md.inlinePatterns['reference'] = \
-            markdown.inlinepatterns.ReferencePattern(SPACED_REFERENCE_RE, md)
-        md.inlinePatterns['image_link'] = \
-            markdown.inlinepatterns.ImagePattern(SPACED_IMAGE_LINK_RE, md)
-        md.inlinePatterns['image_reference'] = \
-            markdown.inlinepatterns.ImageReferencePattern(
-                SPACED_IMAGE_REFERENCE_RE, md)
+
+        md.inlinePatterns.register(
+            SpacedLinkInlineProcessor(LINK_RE, md), 'spaced_link', 500)
+
+        md.inlinePatterns.register(SpacedImageInlineProcessor(
+            IMAGE_LINK_RE, md), 'img_spaced_link', 501)
+
+        md.inlinePatterns.register(SpacedReferenceInlineProcessor(
+            LINK_RE, md), 'spaced_reference', 502)
+
+        md.inlinePatterns.register(SpacedImageReferenceInlineProcessor(
+            IMAGE_LINK_RE, md), 'img_spaced_reference', 503)
+
+
+def makeExtension(**kwargs):
+    return SpacedLinkExtension(**kwargs)

--- a/gfm/spaced_link.py
+++ b/gfm/spaced_link.py
@@ -89,7 +89,3 @@ class SpacedLinkExtension(markdown.Extension):
 
         md.inlinePatterns.register(SpacedImageReferenceInlineProcessor(
             IMAGE_LINK_RE, md), 'img_spaced_reference', 503)
-
-
-def makeExtension(**kwargs):
-    return SpacedLinkExtension(**kwargs)

--- a/mdx_gfm/__init__.py
+++ b/mdx_gfm/__init__.py
@@ -51,4 +51,4 @@ class GithubFlavoredMarkdownExtension(PartialGithubFlavoredMarkdownExtension):
     def extendMarkdown(self, md, md_globals):
         PartialGithubFlavoredMarkdownExtension.extendMarkdown(self, md,
                                                               md_globals)
-        Nl2BrExtension().extendMarkdown(md, md_globals)
+        Nl2BrExtension().extendMarkdown(md)

--- a/mdx_partial_gfm/__init__.py
+++ b/mdx_partial_gfm/__init__.py
@@ -27,7 +27,6 @@ please use :class:`mdx_gfm.GithubFlavoredMarkdownExtension`.
 
 from markdown.extensions import Extension
 from markdown.extensions.fenced_code import FencedCodeExtension
-from markdown.extensions.smart_strong import SmartEmphasisExtension
 from markdown.extensions.tables import TableExtension
 
 import gfm
@@ -59,17 +58,14 @@ class PartialGithubFlavoredMarkdownExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
         # Built-in extensions
-        FencedCodeExtension().extendMarkdown(md, md_globals)
-        SmartEmphasisExtension().extendMarkdown(md, md_globals)
-        TableExtension().extendMarkdown(md, md_globals)
+        FencedCodeExtension().extendMarkdown(md)
+        TableExtension().extendMarkdown(md)
 
         # Custom extensions
         gfm.AutolinkExtension().extendMarkdown(md, md_globals)
         gfm.AutomailExtension().extendMarkdown(md, md_globals)
-        gfm.HiddenHiliteExtension([
-            ('guess_lang', 'False'),
-            ('css_class', 'highlight')
-        ]).extendMarkdown(md, md_globals)
+
+        gfm.HiddenHiliteExtension().extendMarkdown(md, self.config)
         gfm.SemiSaneListExtension().extendMarkdown(md, md_globals)
         gfm.SpacedLinkExtension().extendMarkdown(md, md_globals)
         gfm.StrikethroughExtension().extendMarkdown(md, md_globals)

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     url='https://github.com/zopieux/py-gfm',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['setuptools', 'markdown<3.0'],
-    data_files = [('', ['LICENSE'])],
+    install_requires=['setuptools', 'markdown>=3.0'],
+    data_files=[('', ['LICENSE'])],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tests/test_autolink.py
+++ b/tests/test_autolink.py
@@ -11,7 +11,7 @@ from test_case import TestCase
 
 class TestAutolink(TestCase):
     def setUp(self):
-        self.autolink = gfm.AutolinkExtension([])
+        self.autolink = gfm.AutolinkExtension()
 
     def test_autolinks_obvious_links(self):
         self.assert_renders("""

--- a/tests/test_gfm.py
+++ b/tests/test_gfm.py
@@ -18,8 +18,8 @@ class TestGfm(TestCase):
         extensions = ['gfm']
         if self.has_pygments:
             self.assert_renders("""
-        <div class="highlight"><pre><span></span>foo
-        </pre></div>
+        <div class="highlight"><pre><span></span><code><span class="err">foo</span>
+        </code></pre></div>
         """, test_text, extensions)
         else:
             self.assert_renders("""
@@ -79,8 +79,8 @@ class TestGfm(TestCase):
 
         if self.has_pygments:
             self.assert_renders("""
-        <div class="highlight"><pre><span></span><span class="k">def</span>
-        </pre></div>
+        <div class="highlight"><pre><span></span><code><span class="k">def</span>
+        </code></pre></div>
         """, test_text, extensions)
         else:
             self.assert_renders("""

--- a/tests/test_hidden_hilite.py
+++ b/tests/test_hidden_hilite.py
@@ -12,7 +12,7 @@ from test_case import TestCase
 class TestHiddenHilite(TestCase):
     def setUp(self):
         TestCase.setUp(self)
-        self.hidden_hilite = gfm.HiddenHiliteExtension([])
+        self.hidden_hilite = gfm.HiddenHiliteExtension()
 
     def test_doesnt_highlight_code_blocks(self):
         self.assert_renders("""
@@ -51,8 +51,8 @@ class TestHiddenHilite(TestCase):
         extensions = [self.hidden_hilite, 'fenced_code']
         if self.has_pygments:
             self.assert_renders("""
-        <div class="codehilite"><pre><span></span><span class="k">def</span>
-        </pre></div>
+        <div class="codehilite"><pre><span></span><code><span class="k">def</span>
+        </code></pre></div>
         """, test_text, extensions)
         else:
             self.assert_renders("""

--- a/tests/test_mdx_gfm.py
+++ b/tests/test_mdx_gfm.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+from __future__ import unicode_literals
+
+from test_case import TestCase
+
+
+class TestGfm(TestCase):
+
+    extensions = ['mdx_gfm']
+
+    def test_fenced_code(self):
+        test_text = """
+        ```
+        foo
+        ```
+        """
+        if self.has_pygments:
+            self.assert_renders("""
+        <div class="codehilite"><pre><span></span><code><span class="err">foo</span>
+        </code></pre></div>
+        """, test_text, self.extensions)
+        else:
+            self.assert_renders("""
+        <pre class="codehilite"><code>foo</code></pre>
+        """, test_text, self.extensions)
+
+    def test_nl2br(self):
+        self.assert_renders("""
+        <p>foo<br />
+        bar</p>
+        """, """
+        foo
+        bar
+        """, self.extensions)
+
+    def test_smart_emphasis(self):
+        self.assert_renders("""
+        <p>foo__bar__baz</p>
+        """, """
+        foo__bar__baz
+        """, self.extensions)
+
+    def test_table(self):
+        self.assert_renders("""
+        <table>
+        <thead>
+        <tr>
+        <th>First Header</th>
+        <th>Second Header</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+        </tr>
+        <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+        </tr>
+        </tbody>
+        </table>
+        """, """
+        First Header  | Second Header
+        ------------- | -------------
+        Content Cell  | Content Cell
+        Content Cell  | Content Cell
+        """, self.extensions)
+
+    def test_hilite(self):
+        test_text = """
+        ```.python
+        def
+        ```
+        """
+
+        if self.has_pygments:
+            self.assert_renders("""
+        <div class="codehilite"><pre><span></span><code><span class="k">def</span>
+        </code></pre></div>
+        """, test_text, self.extensions)
+        else:
+            self.assert_renders("""
+        <pre class="codehilite"><code class="language-python">def</code></pre>
+        """, test_text, self.extensions)
+
+    def test_semi_sane_lists(self):
+        self.assert_renders("""
+        <ul>
+        <li>foo</li>
+        </ul>
+        <ol>
+        <li>bar</li>
+        </ol>
+        """, """
+        * foo
+
+        1. bar
+        """, self.extensions)
+
+    def test_autolink(self):
+        self.assert_renders("""
+        <p><a href="http://foo.com/bar">http://foo.com/bar</a></p>
+        """, """
+        http://foo.com/bar
+        """, self.extensions)
+
+    def test_automail(self):
+        self.assert_renders("""
+        <p><a href="mailto:foo@bar.com">foo@bar.com</a></p>
+        """, """
+        foo@bar.com
+        """, self.extensions)
+
+    def test_strikethrough(self):
+        self.assert_renders("""
+        <p>This is <del>struck</del>.</p>
+        """, """
+        This is ~~struck~~.
+        """, self.extensions)
+
+    def test_spaced_link(self):
+        self.assert_renders("""
+        <p><a href="href">text</a></p>
+        """, """
+        [text] (href)
+        """, self.extensions)

--- a/tests/test_semi_sane_lists.py
+++ b/tests/test_semi_sane_lists.py
@@ -11,7 +11,7 @@ from test_case import TestCase
 
 class TestSemiSaneLists(TestCase):
     def setUp(self):
-        self.semi_sane_lists = gfm.SemiSaneListExtension([])
+        self.semi_sane_lists = gfm.SemiSaneListExtension()
 
     def test_doesnt_join_ul_and_ol(self):
         self.assert_renders("""

--- a/tests/test_spaced_link.py
+++ b/tests/test_spaced_link.py
@@ -11,7 +11,7 @@ from test_case import TestCase
 
 class TestMultilineLink(TestCase):
     def setUp(self):
-        self.spaced_link = gfm.SpacedLinkExtension([])
+        self.spaced_link = gfm.SpacedLinkExtension()
 
     def test_normal_link(self):
         self.assert_renders("""

--- a/tests/test_strikethrough.py
+++ b/tests/test_strikethrough.py
@@ -11,7 +11,7 @@ from test_case import TestCase
 
 class TestStrikethrough(TestCase):
     def setUp(self):
-        self.strikethrough = gfm.StrikethroughExtension([])
+        self.strikethrough = gfm.StrikethroughExtension()
 
     def test_double_tilde_strikes(self):
         self.assert_renders("""


### PR DESCRIPTION
I want to use a version compatible with markdown3.x, please release it if possible.

Dropped support for the following Python versions.
  - "2.7"
  - "3.2"
  - "3.3"
