### PR TITLE
Add Markdown 3.3 support

### DIFF
--- a/gfm/standalone_fenced_code.py
+++ b/gfm/standalone_fenced_code.py
@@ -2,6 +2,8 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
+import markdown
+
 from markdown.extensions.fenced_code import FencedCodeExtension, FencedBlockPreprocessor
 
 
@@ -29,12 +31,19 @@ class StandaloneFencedCodeExtension(FencedCodeExtension):
                 "Default: True",
             ],
         }
-        super().setConfigs(kwargs)
+        if markdown.__version_info__ >= (3, 3):
+            super().setConfigs(kwargs)
+        else:
+            super().__init__(**kwargs)
 
     def extendMarkdown(self, md):
         """ Add FencedBlockPreprocessor to the Markdown instance. """
         md.registerExtension(self)
-        processor = FencedBlockPreprocessor(md, self.config)
-        processor.checked_for_codehilite = True
-        processor.codehilite_conf = self.getConfigs()
+        if markdown.__version_info__ >= (3, 3):
+            processor = FencedBlockPreprocessor(md, self.config)
+            processor.codehilite_conf = self.getConfigs()
+        else:
+            processor = FencedBlockPreprocessor(md)
+            processor.checked_for_codehilite = True
+            processor.codehilite_conf = self.config
         md.preprocessors.register(processor, "fenced_code_block", 25)

--- a/gfm/standalone_fenced_code.py
+++ b/gfm/standalone_fenced_code.py
@@ -29,12 +29,12 @@ class StandaloneFencedCodeExtension(FencedCodeExtension):
                 "Default: True",
             ],
         }
-        super().__init__(**kwargs)
+        super().setConfigs(kwargs)
 
     def extendMarkdown(self, md):
         """ Add FencedBlockPreprocessor to the Markdown instance. """
         md.registerExtension(self)
-        processor = FencedBlockPreprocessor(md)
+        processor = FencedBlockPreprocessor(md, self.config)
         processor.checked_for_codehilite = True
-        processor.codehilite_conf = self.config
+        processor.codehilite_conf = self.getConfigs()
         md.preprocessors.register(processor, "fenced_code_block", 25)

--- a/tests/test_gfm.py
+++ b/tests/test_gfm.py
@@ -43,7 +43,8 @@ class TestGfm(TestCase):
         else:
             self.assert_renders(
                 """
-        <pre class="highlight"><code>some code</code></pre>
+        <pre class="highlight"><code>some code
+        </code></pre>
         """,
                 test_text,
                 extensions,
@@ -124,7 +125,8 @@ class TestGfm(TestCase):
         else:
             self.assert_renders(
                 """
-        <pre class="highlight"><code class="language-python">def</code></pre>
+        <pre class="highlight"><code class="language-python">def
+        </code></pre>
         """,
                 test_text,
                 extensions,

--- a/tests/test_gfm.py
+++ b/tests/test_gfm.py
@@ -2,6 +2,8 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
+import markdown
+
 from test_case import TestCase
 
 
@@ -41,13 +43,17 @@ class TestGfm(TestCase):
                 extensions,
             )
         else:
-            self.assert_renders(
-                """
+            if markdown.__version_info__ >= (3, 3):
+                expected_text = """
         <pre class="highlight"><code>some code
         </code></pre>
-        """,
-                test_text,
-                extensions,
+        """
+            else:
+                expected_text = """
+        <pre class="highlight"><code>some code</code></pre>
+        """
+            self.assert_renders(
+                expected_text, test_text, extensions,
             )
 
     def test_nl2br(self):
@@ -123,13 +129,17 @@ class TestGfm(TestCase):
                 extensions,
             )
         else:
-            self.assert_renders(
-                """
+            if markdown.__version_info__ >= (3, 3):
+                expected_text = """
         <pre class="highlight"><code class="language-python">def
         </code></pre>
-        """,
-                test_text,
-                extensions,
+        """
+            else:
+                expected_text = """
+        <pre class="highlight"><code class="language-python">def</code></pre>
+        """
+            self.assert_renders(
+                expected_text, test_text, extensions,
             )
 
     def test_semi_sane_lists(self):


### PR DESCRIPTION
Closes #24. Fixes the errors from Markdown 3.3 by calling `setConfigs` instead of `super().__init__()` in the `__init__` method because `FencedCodeExtension.__init__` now also sets a default in `self.config` that overrides the defaults here. Also passes the config to `FencedBlockPreprocessor` and `codehilite_conf` in the formats they now need. Updates tests to reflect that now the CodeHilite extension [also adds a newline before the closing tag](https://github.com/Python-Markdown/markdown/pull/816/files#diff-934821cde110094c262f0f04b5e98feadce02b43ea311dd1c3d72d77b5c44860R158).

The tests for Python 3.5 are failing because Markdown 3.3 removes support for 3.5, but I haven't removed them here. Not sure about how to maintain compatibility with earlier versions of Markdown or if that's desirable here, but let me know if there's anything I should change, thanks! 