### PR TITLE
fix: the module 'markdown.util' was updated

### DIFF
--- a/gfm/tasklist.py
+++ b/gfm/tasklist.py
@@ -180,7 +180,7 @@ Typical usage
 import markdown
 from functools import reduce
 from markdown.treeprocessors import Treeprocessor
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 
 
 def _to_list(obj):


### PR DESCRIPTION
error: cannot import name 'etree' from 'markdown.util'.

I read the README, `This repository will not receive bug fixes, and might become read-only soon.`, but I think this bug is worthy of being merged.